### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -35,10 +35,10 @@ path = [
     "**/*Icon-*.png", "web/favicon.png",
     "**/*launcher.png"]
 precedence = "override"
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"
 [[annotations]]
 path = ["**/*.g.dart", "**/*.freezed.dart", "**/*generated_*", "**/*Generated*", "**/windows/runner/Runner.rc"]
 precedence = "override"
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG Generated Code"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others Generated Code"
 SPDX-License-Identifier = "Apache-2.0"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/main/kotlin/com/example/arc_view/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/arc_view/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+  ~ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ios/Runner/Runner-Bridging-Header.h
+++ b/ios/Runner/Runner-Bridging-Header.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/address_bar.dart
+++ b/lib/src/chat/address_bar.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/buttons/new_conversation_button.dart
+++ b/lib/src/chat/buttons/new_conversation_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/buttons/send_message_button.dart
+++ b/lib/src/chat/buttons/send_message_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/buttons/show_previous_prompts_button.dart
+++ b/lib/src/chat/buttons/show_previous_prompts_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/chat_field.dart
+++ b/lib/src/chat/chat_field.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/chat_list.dart
+++ b/lib/src/chat/chat_list.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/chat_panel.dart
+++ b/lib/src/chat/chat_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/chat_screen.dart
+++ b/lib/src/chat/chat_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/dialogs/apply_usecase_dialog.dart
+++ b/lib/src/chat/dialogs/apply_usecase_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/message/bot_chat_message_card.dart
+++ b/lib/src/chat/message/bot_chat_message_card.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/message/chat_message_card.dart
+++ b/lib/src/chat/message/chat_message_card.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/message/copy_to_clipboard_button.dart
+++ b/lib/src/chat/message/copy_to_clipboard_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/message/rerun_message_button.dart
+++ b/lib/src/chat/message/rerun_message_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/notifiers/selected_usecase_notifier.dart
+++ b/lib/src/chat/notifiers/selected_usecase_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/right_panel.dart
+++ b/lib/src/chat/right_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/services/message_sender.dart
+++ b/lib/src/chat/services/message_sender.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/toolbar/agent_tabs.dart
+++ b/lib/src/chat/toolbar/agent_tabs.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/toolbar/chat_tool_bar.dart
+++ b/lib/src/chat/toolbar/chat_tool_bar.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/chat/toolbar/tool_bar.dart
+++ b/lib/src/chat/toolbar/tool_bar.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/graphql/agent_query.dart
+++ b/lib/src/client/graphql/agent_query.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/graphql/agent_subscription.dart
+++ b/lib/src/client/graphql/agent_subscription.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/graphql/event_subscription.dart
+++ b/lib/src/client/graphql/event_subscription.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/models/system_context.dart
+++ b/lib/src/client/models/system_context.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/models/user_context.dart
+++ b/lib/src/client/models/user_context.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/notifiers/agent_client_notifier.dart
+++ b/lib/src/client/notifiers/agent_client_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/notifiers/agents_notifier.dart
+++ b/lib/src/client/notifiers/agents_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/client/oneai_client.dart
+++ b/lib/src/client/oneai_client.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/conversations_panel.dart
+++ b/lib/src/conversation/conversations_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/models/conversation.dart
+++ b/lib/src/conversation/models/conversation.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/models/conversation_export.dart
+++ b/lib/src/conversation/models/conversation_export.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/models/conversation_message.dart
+++ b/lib/src/conversation/models/conversation_message.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/models/conversations.dart
+++ b/lib/src/conversation/models/conversations.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/notifiers/conversations_notifier.dart
+++ b/lib/src/conversation/notifiers/conversations_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/services/conversation_colors.dart
+++ b/lib/src/conversation/services/conversation_colors.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/services/conversation_exporter.dart
+++ b/lib/src/conversation/services/conversation_exporter.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/conversation/services/conversation_importer.dart
+++ b/lib/src/conversation/services/conversation_importer.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/core/secondary_button.dart
+++ b/lib/src/core/secondary_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/core/text.dart
+++ b/lib/src/core/text.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/core/text_input_dialog.dart
+++ b/lib/src/core/text_input_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/action_event.dart
+++ b/lib/src/events/action_event.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/event_row_item.dart
+++ b/lib/src/events/event_row_item.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/events_list.dart
+++ b/lib/src/events/events_list.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/events_panel.dart
+++ b/lib/src/events/events_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/events_screen.dart
+++ b/lib/src/events/events_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/milestone_event.dart
+++ b/lib/src/events/milestone_event.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/models/agent_events.dart
+++ b/lib/src/events/models/agent_events.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/notifiers/agent_events_notifier.dart
+++ b/lib/src/events/notifiers/agent_events_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/events/prompt_view.dart
+++ b/lib/src/events/prompt_view.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/home/home_panel.dart
+++ b/lib/src/home/home_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/home/home_screen.dart
+++ b/lib/src/home/home_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/layout/adaptive_scaffold.dart
+++ b/lib/src/layout/adaptive_scaffold.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/layout/main_layout.dart
+++ b/lib/src/layout/main_layout.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/agent_duration_chart.dart
+++ b/lib/src/metrics/charts/agent_duration_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/agent_flowbreaks_chart.dart
+++ b/lib/src/metrics/charts/agent_flowbreaks_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/data_bar_chart.dart
+++ b/lib/src/metrics/charts/data_bar_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/data_chart.dart
+++ b/lib/src/metrics/charts/data_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/data_line_chart.dart
+++ b/lib/src/metrics/charts/data_line_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/function_calls_chart.dart
+++ b/lib/src/metrics/charts/function_calls_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/llm_duration_chart.dart
+++ b/lib/src/metrics/charts/llm_duration_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts/tokens_chart.dart
+++ b/lib/src/metrics/charts/tokens_chart.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/charts_screen.dart
+++ b/lib/src/metrics/charts_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/metric_details.dart
+++ b/lib/src/metrics/metric_details.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/models/metrics.dart
+++ b/lib/src/metrics/models/metrics.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/notifiers/agent_metrics_notifier.dart
+++ b/lib/src/metrics/notifiers/agent_metrics_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/services/events_to_metrics_converter.dart
+++ b/lib/src/metrics/services/events_to_metrics_converter.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/services/metrics_exporter.dart
+++ b/lib/src/metrics/services/metrics_exporter.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/metrics/services/metrics_importer.dart
+++ b/lib/src/metrics/services/metrics_importer.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/prompts/notifiers/current_prompt_notifier.dart
+++ b/lib/src/prompts/notifiers/current_prompt_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/prompts/notifiers/prompt_history_notifier.dart
+++ b/lib/src/prompts/notifiers/prompt_history_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/prompts/prompt_list.dart
+++ b/lib/src/prompts/prompt_list.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/prompts/repositories/history_repository.dart
+++ b/lib/src/prompts/repositories/history_repository.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/settings/context_field.dart
+++ b/lib/src/settings/context_field.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/settings/models/settings.dart
+++ b/lib/src/settings/models/settings.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/settings/notifiers/settings_notifier.dart
+++ b/lib/src/settings/notifiers/settings_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/settings/settings_screen.dart
+++ b/lib/src/settings/settings_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/theme_notifier.dart
+++ b/lib/src/theme_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/themes.dart
+++ b/lib/src/themes.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/buttons/add_usecases_button.dart
+++ b/lib/src/usecases/buttons/add_usecases_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/buttons/import_usecases_button.dart
+++ b/lib/src/usecases/buttons/import_usecases_button.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/models/use_cases.dart
+++ b/lib/src/usecases/models/use_cases.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/notifiers/usecases_notifier.dart
+++ b/lib/src/usecases/notifiers/usecases_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/repositories/usecase_repository.dart
+++ b/lib/src/usecases/repositories/usecase_repository.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/search/notifiers/search_notifier.dart
+++ b/lib/src/usecases/search/notifiers/search_notifier.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/search/search_panel.dart
+++ b/lib/src/usecases/search/search_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/search/syntax_text_controller.dart
+++ b/lib/src/usecases/search/syntax_text_controller.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/services/usecase_exporter.dart
+++ b/lib/src/usecases/services/usecase_exporter.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/services/usecase_importer.dart
+++ b/lib/src/usecases/services/usecase_importer.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecase_list.dart
+++ b/lib/src/usecases/usecase_list.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecase_overview_panel.dart
+++ b/lib/src/usecases/usecase_overview_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecase_panel.dart
+++ b/lib/src/usecases/usecase_panel.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecase_syntax.dart
+++ b/lib/src/usecases/usecase_syntax.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecase_template.dart
+++ b/lib/src/usecases/usecase_template.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lib/src/usecases/usecases_screen.dart
+++ b/lib/src/usecases/usecases_screen.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 # Project-level configuration.

--- a/linux/flutter/CMakeLists.txt
+++ b/linux/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 # This file controls Flutter-level build steps. It should not be edited.

--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 // 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 // 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/linux/my_application.h
+++ b/linux/my_application.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 // 
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/macos/Runner/Configs/Debug.xcconfig
+++ b/macos/Runner/Configs/Debug.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Runner/Configs/Release.xcconfig
+++ b/macos/Runner/Configs/Release.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Runner/Configs/Warnings.xcconfig
+++ b/macos/Runner/Configs/Warnings.xcconfig
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/test_preferences.dart
+++ b/test/test_preferences.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/widget_chat_test.dart
+++ b/test/widget_chat_test.dart
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!-- 
- SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
  SPDX-License-Identifier: Apache-2.0
 -->

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 # This file controls Flutter-level build steps. It should not be edited.

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # 
 # SPDX-License-Identifier: Apache-2.0
 cmake_minimum_required(VERSION 3.14)

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/resource.h
+++ b/windows/runner/resource.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/runner.exe.manifest
+++ b/windows/runner/runner.exe.manifest
@@ -1,5 +1,5 @@
 <!-- 
- SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
  SPDX-License-Identifier: Apache-2.0
 -->

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
See https://www.eclipse.org/projects/handbook/#ip-copyright-headers