### PR TITLE
Use flutter version 3.29.1 also when building for the docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.1'
+          flutter-version: '3.29.1'
           cache: true
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
The version was already increased in the build job, where the build succeeds - but not in the publish job where the build fails